### PR TITLE
Set EncryptKey to be JsonIgnore in RemoteDataBrokerReponse

### DIFF
--- a/Bezlio Plugin Common/RemoteDataBrokerResponse.cs
+++ b/Bezlio Plugin Common/RemoteDataBrokerResponse.cs
@@ -130,7 +130,7 @@ namespace bezlio.rdb
             }
         }
 
-        [JsonProperty(PropertyName = "encryptKey")]
+        [JsonIgnore]
         public string EncryptKey { get; set; }
 
         [JsonProperty(PropertyName = "requestId")]


### PR DESCRIPTION
This will prevent it from being included in the encrypted data packet. We do not need it included because we know it from the client side of things. Closes #147