### PR TITLE
Updates to SQL Server Parameter

### DIFF
--- a/Bezlio Plugin Common/Logging/Logging.cs
+++ b/Bezlio Plugin Common/Logging/Logging.cs
@@ -20,7 +20,7 @@ namespace bezlio.Logging
 
         public static BezlioLog Instance { get { return lazy.Value; } }
 
-        private BezlioLog()
+        public BezlioLog()
         {
             
         }

--- a/Plugins/SQLServer/SQLServerPlugin.cs
+++ b/Plugins/SQLServer/SQLServerPlugin.cs
@@ -292,7 +292,7 @@ namespace bezlio.rdb.plugins
 
                 // Perform any replacements on passed variables
                 if (request.Parameters != null && request.Parameters.Count > 0)
-                    request.Parameters = FillQueryParameters(ref sql, request.Parameters);
+                    FillQueryParameters(ref sql, request.Parameters);
 
                 // Now obtain a SQL connection
                 object sqlConn = getConnection("SQL Server"
@@ -767,6 +767,16 @@ namespace bezlio.rdb.plugins
 
                 string value = parameter.Value.ToString().Replace("'", "''");
                 double number;
+
+                // See if we've already defined the SQL parameter
+                foreach (SqlParameter p in command.Parameters)
+                {
+                    if (p.ParameterName == useKey)
+                    {
+                        // We dont want to add it again
+                        return;
+                    }
+                }
                 SqlParameter param;
 
                 if (!(value.StartsWith("\"") && value.EndsWith("\"")) && double.TryParse(value, out number))


### PR DESCRIPTION
Made Logging constructor not be public so it could be added for testing when a plugin is acting foolishly. Updated the parameter checking to only add the parameter a single time and do not overwrite the request parameters because it was removing one for some reason.